### PR TITLE
Add: API - accept cached locations batch

### DIFF
--- a/src/main/java/org/traccar/protocol/OsmAndProtocolDecoder.java
+++ b/src/main/java/org/traccar/protocol/OsmAndProtocolDecoder.java
@@ -24,6 +24,7 @@ import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.codec.http.QueryStringDecoder;
 import jakarta.json.Json;
 import jakarta.json.JsonObject;
+import jakarta.json.JsonValue;
 import org.traccar.BaseHttpProtocolDecoder;
 import org.traccar.helper.UnitsConverter;
 import org.traccar.session.DeviceSession;
@@ -217,6 +218,13 @@ public class OsmAndProtocolDecoder extends BaseHttpProtocolDecoder {
 
     private Object decodeJson(
             Channel channel, SocketAddress remoteAddress, FullHttpRequest request) throws Exception {
+        String content = request.content().toString(StandardCharsets.UTF_8);
+        return decodeJsonObject(channel, remoteAddress, request);
+
+
+    }
+
+    private Position decodeJsonObject(Channel channel, SocketAddress remoteAddress, FullHttpRequest request) {
 
         String content = request.content().toString(StandardCharsets.UTF_8);
         JsonObject root = Json.createReader(new StringReader(content)).readObject();


### PR DESCRIPTION
Add: API - accept locations batch. The OsmAnd Protocol now accepts both single object and an array of objects on the same endpoint to support backward compatibility. 